### PR TITLE
Perform part of the pipeline using Flow

### DIFF
--- a/lib/typo_killer/finder.ex
+++ b/lib/typo_killer/finder.ex
@@ -14,7 +14,6 @@ defmodule TypoKiller.Finder do
     |> Flow.from_enumerable()
     |> Flow.map(fn word -> calculate_distance(word, dictionary) end)
     |> Flow.reduce(fn -> MapSet.new() end, fn a, b -> MapSet.union(MapSet.new(a), b) end)
-    |> Enum.to_list()
     |> MapSet.new()
     |> MapSet.delete(nil)
   end

--- a/lib/typo_killer/finder.ex
+++ b/lib/typo_killer/finder.ex
@@ -11,8 +11,10 @@ defmodule TypoKiller.Finder do
 
   def find_typos({words, dictionary}) do
     words
-    |> Enum.map(&Task.async(fn -> calculate_distance(&1, dictionary) end))
-    |> Enum.flat_map(&Task.await(&1, :infinity))
+    |> Flow.from_enumerable()
+    |> Flow.map(fn word -> calculate_distance(word, dictionary) end)
+    |> Flow.reduce(fn -> MapSet.new() end, fn a, b -> MapSet.union(MapSet.new(a), b) end)
+    |> Enum.to_list()
     |> MapSet.new()
     |> MapSet.delete(nil)
   end

--- a/lib/typo_killer/finder.ex
+++ b/lib/typo_killer/finder.ex
@@ -13,9 +13,14 @@ defmodule TypoKiller.Finder do
     words
     |> Flow.from_enumerable()
     |> Flow.map(fn word -> calculate_distance(word, dictionary) end)
-    |> Flow.reduce(fn -> MapSet.new() end, fn a, b -> MapSet.union(MapSet.new(a), b) end)
+    |> Flow.reduce(fn -> MapSet.new() end, &merge_partial_result/2)
     |> MapSet.new()
     |> MapSet.delete(nil)
+  end
+
+  defp merge_partial_result(partial_result, acc) do
+    partial_result_mapset = MapSet.new(partial_result)
+    MapSet.union(partial_result_mapset, acc)
   end
 
   @spec calculate_distance(word :: String.t(), dict :: list(String.t())) :: list(String.t() | nil)

--- a/lib/typo_killer/words_parser.ex
+++ b/lib/typo_killer/words_parser.ex
@@ -17,7 +17,12 @@ defmodule TypoKiller.WordsParser do
     |> MapSet.new()
   end
 
-  @spec find_words(file :: String.t()) :: list()
+  def file_to_words(file) do
+    file
+    |> find_words()
+    |> MapSet.new()
+  end
+
   defp find_words(file) do
     file
     |> File.read!()

--- a/lib/typo_killer/words_parser.ex
+++ b/lib/typo_killer/words_parser.ex
@@ -17,6 +17,10 @@ defmodule TypoKiller.WordsParser do
     |> MapSet.new()
   end
 
+  @doc """
+  Retrieve words from one file and generate a new mapset with them
+  """
+  @spec file_to_words(String.t()) :: MapSet.t()
   def file_to_words(file) do
     file
     |> find_words()

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,8 @@ defmodule TypoKiller.MixProject do
     [
       {:benchee, "~> 1.0", only: :dev},
       {:dialyxir, "~> 0.5.1", only: :dev, runtime: false},
-      {:ex_doc, "~> 0.21", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.21", only: :dev, runtime: false},
+      {:flow, "~> 0.15.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -5,6 +5,8 @@
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "flow": {:hex, :flow, "0.15.0", "503717c0e367b5713336181d5305106840f64abbad32c75d7af5ef1bb0908e38", [:mix], [{:gen_stage, "~> 0.14.0", [hex: :gen_stage, repo: "hexpm", optional: false]}], "hexpm"},
+  "gen_stage": {:hex, :gen_stage, "0.14.3", "d0c66f1c87faa301c1a85a809a3ee9097a4264b2edf7644bf5c123237ef732bf", [:mix], [], "hexpm"},
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.2", "1d71150d5293d703a9c38d4329da57d3935faed2031d64bc19e77b654ef2d177", [:mix], [], "hexpm"},


### PR DESCRIPTION
Leverage the most expensive part of the processing pipeline to Flow

## Benchmark

I ran both benchmarks with a small Phoenix project. The results are:

*Without Flow*
```
Name                 ips        average  deviation         median         99th %
find_typos        0.0116       1.43 min     ±0.00%       1.43 min       1.43 min

Memory usage statistics:

Name          Memory usage
find_typos         1.28 GB
```

*With Flow*
```
Name                 ips        average  deviation         median         99th %
find_typos        0.0120       1.38 min     ±0.00%       1.38 min       1.38 min

Memory usage statistics:

Name          Memory usage
find_typos        46.34 MB
```

### Summary
```
Time performance: -4.9%
Memory usage:    -96.3%
```