### PR TITLE
Create a CLI with escript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ typo_killer-*.tar
 
 # Ignore Elixir LS (dialyzer) build folder
 /.elixir_ls/
+
+# Escript generated binaries
+/bin/

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # Typo Killer
 ### _qu'est que ce_
 
-#### Usage
+#### Building
 
-With elixir installed, open `typo_killer` folder and use the following commands on your terminal:
+With elixir installed, open `typo_killer` folder and use the following commands
+on your terminal:
 
 ```
 mix deps.get
 mix compile
 ```
+
+#### Simple Usage
 
 **Using iex**
 
@@ -24,7 +27,25 @@ Then just: `TypoKiller.find_typos("path/to/folder")`
 
 Just run `mix typo_killer path/to/folder`
 
+#### Creating a binary
+
+This will create a self contained executable file which will include everything
+that you need to run TypoKiller. This file can be distributed to other people
+and they don't need to have an Erlang runtime installed - it's all in the
+binary file.
+
+To create it, run:
+
+```
+mix escript.build
+```
+
+This will generate an executable file `bin/typokiller`. Now run
+`./bin/typokiller --help` for more information.
+
+
 #### Typo Killer on the wild
+
 Are you using Typo Killer on big repos? Send a PR adding it here! :slightly_smiling_face:
 - [Elixir](https://github.com/elixir-lang/elixir/pull/9611)
 - [Ecto](https://github.com/elixir-ecto/ecto/pull/3174)

--- a/lib/typo_killer.ex
+++ b/lib/typo_killer.ex
@@ -19,6 +19,8 @@ defmodule TypoKiller do
   """
   @spec find_typos(path :: binary()) :: :ok | {:error, String.t()}
   def find_typos(path \\ ".") do
+    IO.puts("Running on path \"#{path}\"...")
+
     path
     |> FileParser.find_files_on_folder()
     |> WordsParser.files_to_words()

--- a/lib/typo_killer/cli.ex
+++ b/lib/typo_killer/cli.ex
@@ -1,0 +1,89 @@
+defmodule TypoKiller.CLI do
+  @cli_options [
+    allow_nonexistent_atoms: false,
+    strict: [
+      path: :string,
+      help: :boolean
+    ],
+    aliases: [
+      p: :path,
+      h: :help
+    ]
+  ]
+
+  @available_cmds ["run"]
+
+  def main(argv \\ []) do
+    argv
+    |> OptionParser.parse(@cli_options)
+    |> launch()
+  end
+
+  defp launch({options, command, []}) do
+    cond do
+      options[:help] ->
+        print_help()
+
+      true ->
+        do_launch(command, options)
+    end
+  end
+
+  defp launch({_options, _command, invalid_args}) do
+    cmd_str =
+      invalid_args
+      |> Enum.map(fn {opt, _} -> opt end)
+      |> Enum.join("\n")
+
+    """
+    Error -  invalid args:
+
+    #{cmd_str}
+    """
+    |> IO.puts()
+  end
+
+  defp do_launch(["run"], options) do
+    path = options[:path] || "."
+
+    TypoKiller.find_typos(path)
+  end
+
+  defp do_launch([], _options) do
+    """
+    Error: no action provided.
+
+    Available actions: #{Enum.join(@available_cmds, ", ")}
+    """
+    |> IO.puts()
+  end
+
+  defp do_launch(command, _options) do
+    """
+    Error: unknown action '#{command}'.
+
+    Available: #{Enum.join(@available_cmds, ", ")}
+    """
+    |> IO.puts()
+  end
+
+  defp print_help do
+    """
+    TypoKiller - qu'est que ce
+    ---------------------
+    Usage:
+      typokiller <command> <options>
+
+    Available commands: #{Enum.join(@available_cmds, ", ")}
+
+    Options
+      -p, --path <path>          Run TypoKiller in the given path
+
+    Example:
+
+      detektive run --path ~/my_project
+
+    """
+    |> IO.puts()
+  end
+end

--- a/lib/typo_killer/finder.ex
+++ b/lib/typo_killer/finder.ex
@@ -27,7 +27,7 @@ defmodule TypoKiller.Finder do
       with true <- bag_distance >= @minimum_bag_distance,
            jaro_distance <- String.jaro_distance(word, word_from_dict),
            true <- jaro_distance >= @minimum_jaro_distance and jaro_distance < 1.0 do
-        IO.inspect(word)
+        word
       else
         false -> nil
       end

--- a/mix.exs
+++ b/mix.exs
@@ -16,6 +16,7 @@ defmodule TypoKiller.MixProject do
         plt_add_apps: [:mix],
         remove_defaults: [:unknown]
       ],
+      escript: escript(),
       name: "Typo Killer",
       source_url: @repo,
       docs: [
@@ -28,6 +29,13 @@ defmodule TypoKiller.MixProject do
   def application do
     [
       extra_applications: [:logger]
+    ]
+  end
+
+  defp escript do
+    [
+      main_module: TypoKiller.CLI,
+      path: "bin/typokiller"
     ]
   end
 


### PR DESCRIPTION
This PR introduces a very simple and basic CLI so users can run typo killer without the need to have elixir or erlang installed. Escript takes care of everything.

First, create the executable:

```
mix escript.build
```

Now you can run it:

```
./bin/typokiller run --path ~/git/my_project
```

Fixes #2 