### PR TITLE
Keep track of files and line numbers

### DIFF
--- a/lib/typo_killer.ex
+++ b/lib/typo_killer.ex
@@ -50,8 +50,11 @@ defmodule TypoKiller do
       IO.puts("-> candidate: \"#{word}\"")
 
       Enum.each(list_of_occurrences, fn {file, lines} ->
-        IO.puts("  -> #{file}")
-        IO.puts("    -> Lines: #{Enum.join(lines, ", ")}")
+        """
+          -> #{file}
+            -> Lines: #{Enum.join(lines, ", ")}
+        """
+        |> IO.puts()
       end)
     end)
 

--- a/lib/typo_killer.ex
+++ b/lib/typo_killer.ex
@@ -23,7 +23,14 @@ defmodule TypoKiller do
 
     if options != [] do
       IO.puts("Options:")
-      Enum.each(options, fn {k, v} -> IO.puts("  #{Atom.to_string(k)} -> #{inspect(v)}") end)
+
+      Enum.each(options, fn
+        {k, v} when is_list(v) ->
+          IO.puts("  #{Atom.to_string(k)} -> #{Enum.join(v, ", ")}")
+
+        {k, v} ->
+          IO.puts("  #{Atom.to_string(k)} -> #{inspect(v)}")
+      end)
     end
 
     IO.puts("---")

--- a/lib/typo_killer.ex
+++ b/lib/typo_killer.ex
@@ -18,11 +18,19 @@ defmodule TypoKiller do
   Scan a folder, find all possible typos and log them
   """
   @spec find_typos(path :: binary()) :: :ok | {:error, String.t()}
-  def find_typos(path \\ ".") do
-    IO.puts("Running on path \"#{path}\"...")
+  def find_typos(path \\ ".", options \\ []) do
+    IO.puts("Path: \"#{path}\"")
+
+    if options != [] do
+      IO.puts("Options:")
+      Enum.each(options, fn {k, v} -> IO.puts("  #{Atom.to_string(k)} -> #{inspect(v)}") end)
+    end
+
+    IO.puts("---")
+    IO.puts("Running...")
 
     path
-    |> FileParser.find_files_on_folder()
+    |> FileParser.find_files_on_folder(options)
     |> WordsParser.files_to_words()
     |> Dictionary.create()
     |> Finder.find_typos()
@@ -31,14 +39,14 @@ defmodule TypoKiller do
 
   @spec print_typo_candidates(possible_typos :: MapSet.t()) :: :ok | {:error, String.t()}
   defp print_typo_candidates(possible_typos) do
-    Logger.info("There are #{MapSet.size(possible_typos)} possible typos on your folder!")
+    Enum.each(possible_typos, fn {word, list_of_ocurrences} ->
+      IO.puts("-> candidate: \"#{word}\"")
 
-    if MapSet.size(possible_typos) > 0 do
-      Logger.info("Here are the official typo candidates:")
-
-      possible_typos
-      |> Enum.each(&Logger.info("#{&1}"))
-    end
+      Enum.each(list_of_ocurrences, fn {file, lines} ->
+        IO.puts("  -> #{file}")
+        IO.puts("    -> Lines: #{Enum.join(lines, ", ")}")
+      end)
+    end)
 
     :ok
   end

--- a/lib/typo_killer.ex
+++ b/lib/typo_killer.ex
@@ -46,10 +46,10 @@ defmodule TypoKiller do
 
   @spec print_typo_candidates(possible_typos :: MapSet.t()) :: :ok | {:error, String.t()}
   defp print_typo_candidates(possible_typos) do
-    Enum.each(possible_typos, fn {word, list_of_ocurrences} ->
+    Enum.each(possible_typos, fn {word, list_of_occurrences} ->
       IO.puts("-> candidate: \"#{word}\"")
 
-      Enum.each(list_of_ocurrences, fn {file, lines} ->
+      Enum.each(list_of_occurrences, fn {file, lines} ->
         IO.puts("  -> #{file}")
         IO.puts("    -> Lines: #{Enum.join(lines, ", ")}")
       end)

--- a/lib/typo_killer/dictionary.ex
+++ b/lib/typo_killer/dictionary.ex
@@ -17,10 +17,10 @@ defmodule TypoKiller.Dictionary do
   @spec create(words :: MapSet.t()) :: {MapSet.t(), MapSet.t()}
   def create(words)
 
-  def create(%MapSet{} = words) do
+  def create({%MapSet{} = words, word_map}) do
     dictionary = MapSet.union(words, @ignored_words_mapset)
-    words = MapSet.difference(words, @ignored_words_mapset)
-
-    {words, dictionary}
+    {words, dictionary, word_map}
   end
+
+  def ignored_words_mapset, do: @ignored_words_mapset
 end

--- a/lib/typo_killer/finder.ex
+++ b/lib/typo_killer/finder.ex
@@ -9,13 +9,17 @@ defmodule TypoKiller.Finder do
   """
   @spec find_typos({words :: MapSet.t(), dictionary :: MapSet.t()}) :: MapSet.t()
 
-  def find_typos({words, dictionary}) do
-    words
-    |> Flow.from_enumerable()
-    |> Flow.map(fn word -> calculate_distance(word, dictionary) end)
-    |> Flow.reduce(fn -> MapSet.new() end, &merge_partial_result/2)
-    |> MapSet.new()
-    |> MapSet.delete(nil)
+  def find_typos({words, dictionary, word_map}) do
+    candidates =
+      words
+      |> Flow.from_enumerable()
+      |> Flow.map(fn word -> calculate_distance(word, dictionary) end)
+      |> Flow.reduce(fn -> MapSet.new() end, &merge_partial_result/2)
+      |> MapSet.new()
+      |> MapSet.delete(nil)
+      |> Enum.to_list()
+
+    Map.take(word_map, candidates)
   end
 
   defp merge_partial_result(partial_result, acc) do

--- a/lib/typo_killer/words_parser.ex
+++ b/lib/typo_killer/words_parser.ex
@@ -42,9 +42,9 @@ defmodule TypoKiller.WordsParser do
 
     updated_acc_map =
       Enum.reduce(word_map, acc_map, fn {word, lines}, acc ->
-        ocurrences = Map.get(acc, word, [])
-        updated_ocurrences = [{file, lines} | ocurrences]
-        Map.put(acc, word, updated_ocurrences)
+        occurrences = Map.get(acc, word, [])
+        updated_occurrences = [{file, lines} | occurrences]
+        Map.put(acc, word, updated_occurrences)
       end)
 
     {updated_words, updated_acc_map}

--- a/lib/typo_killer/words_parser.ex
+++ b/lib/typo_killer/words_parser.ex
@@ -3,35 +3,73 @@ defmodule TypoKiller.WordsParser do
   Manage words from files and parse them to analyze if they are possible typos or not
   """
 
+  alias TypoKiller.Dictionary
+
   @doc """
   Retrieve words from files and generate a new mapset based on filters
   """
-  @spec files_to_words(files :: list(String.t()) | []) :: MapSet.t()
+  @spec files_to_words(files :: list(String.t()) | []) :: {MapSet.t(), map}
   def files_to_words(files)
 
-  def files_to_words(files) when is_list(files) and length(files) == 0, do: MapSet.new()
+  def files_to_words(files) when is_list(files) and length(files) == 0, do: {MapSet.new(), %{}}
 
   def files_to_words(files) when is_list(files) and length(files) > 0 do
     files
-    |> Enum.flat_map(&find_words/1)
-    |> MapSet.new()
+    |> Flow.from_enumerable()
+    |> Flow.map(&parse_file/1)
+    |> Enum.to_list()
+    |> Enum.reduce({MapSet.new(), %{}}, &merge_file_list_results/2)
   end
 
-  @doc """
-  Retrieve words from one file and generate a new mapset with them
-  """
-  @spec file_to_words(String.t()) :: MapSet.t()
-  def file_to_words(file) do
-    file
-    |> find_words()
-    |> MapSet.new()
+  def parse_file(file) do
+    word_map =
+      file
+      |> File.stream!()
+      |> Stream.with_index()
+      |> Stream.map(&parse_line/1)
+      |> Enum.reduce(%{}, &merge_file_results/2)
+
+    words =
+      word_map
+      |> Map.keys()
+      |> MapSet.new()
+
+    {file, words, word_map}
   end
 
-  defp find_words(file) do
-    file
-    |> File.read!()
+  defp merge_file_list_results({file, words, word_map}, {acc_words, acc_map}) do
+    updated_words = MapSet.union(words, acc_words)
+
+    updated_acc_map =
+      Enum.reduce(word_map, acc_map, fn {word, lines}, acc ->
+        ocurrences = Map.get(acc, word, [])
+        updated_ocurrences = [{file, lines} | ocurrences]
+        Map.put(acc, word, updated_ocurrences)
+      end)
+
+    {updated_words, updated_acc_map}
+  end
+
+  defp parse_line({line, number}) do
+    line
     |> String.downcase()
-    |> String.split(["\n", "_", " "], trim: true)
-    |> Enum.flat_map(&Regex.split(~r/[^a-zA-Z]+/, &1, trim: true))
+    |> String.split(["_", " "], trim: true)
+    |> Enum.flat_map(&split_function/1)
+    |> Enum.filter(&ignore_words_filter/1)
+    |> Map.new(&{&1, [number]})
+  end
+
+  defp split_function(word) do
+    Regex.split(~r/[^a-zA-Z]+/, word, trim: true)
+  end
+
+  defp ignore_words_filter(word) do
+    !MapSet.member?(Dictionary.ignored_words_mapset(), word)
+  end
+
+  defp merge_file_results(entry, acc) do
+    Map.merge(entry, acc, fn _key, v1, v2 ->
+      v1 ++ v2
+    end)
   end
 end

--- a/lib/typo_killer/words_parser.ex
+++ b/lib/typo_killer/words_parser.ex
@@ -25,7 +25,7 @@ defmodule TypoKiller.WordsParser do
     word_map =
       file
       |> File.stream!()
-      |> Stream.with_index()
+      |> Stream.with_index(1)
       |> Stream.map(&parse_line/1)
       |> Enum.reduce(%{}, &merge_file_results/2)
 


### PR DESCRIPTION
**Summary**

This PR changes the way we read files: instead of reading the entire content of a file, we stream it and read it line by line. This allow us to do some optimizations:

- We can ignore words when reading files, instead of doing it later
- By streaming files, we read them as needed, reducing the amount of memory that we use to process the whole thing
- We can keep track of the line number
- We can paralelize it with Flow

**New output format**

This PR also changes the output format so we can see where to find the typos.

Example:
```
$ ./bin/typokiller run --path "./lib"
Path: "./lib"
---
Running...
-> candidate: "commits"
  -> ./lib/typo_killer.ex
    -> Lines: 8
```
Fixes #10 