### PR TITLE
Show the compared word and the score of a candidate

### DIFF
--- a/lib/typo_killer.ex
+++ b/lib/typo_killer.ex
@@ -46,8 +46,8 @@ defmodule TypoKiller do
 
   @spec print_typo_candidates(possible_typos :: MapSet.t()) :: :ok | {:error, String.t()}
   defp print_typo_candidates(possible_typos) do
-    Enum.each(possible_typos, fn {word, list_of_occurrences} ->
-      IO.puts("-> candidate: \"#{word}\"")
+    Enum.each(possible_typos, fn {word, {compared_word, score, list_of_occurrences}} ->
+      IO.puts("-> \"#{word}\" looks like \"#{compared_word}\" (#{score})")
 
       Enum.each(list_of_occurrences, fn {file, lines} ->
         """


### PR DESCRIPTION
Keep track of score and compared word and displays it to the output. This will make it easier to find actual typos.

Output sample:

```
-> "commits" looks like "commit" (0.9523809523809524)
  -> ./lib/typo_killer.ex
    -> Lines: 9

-> "dictionar" looks like "dictionary" (0.9666666666666667)
  -> ./lib/typo_killer.ex
    -> Lines: 47

```