### PR TITLE
Candidates and pretty output

### DIFF
--- a/lib/typo_killer.ex
+++ b/lib/typo_killer.ex
@@ -10,8 +10,9 @@ defmodule TypoKiller do
   """
   require Logger
   alias TypoKiller.Files
-  alias TypoKiller.Words
+  alias TypoKiller.Output
   alias TypoKiller.Typos
+  alias TypoKiller.Words
 
   @doc """
   Scan a folder, find all possible typos and log them
@@ -39,23 +40,7 @@ defmodule TypoKiller do
     |> Files.find_files_on_folder(options)
     |> Words.files_to_words()
     |> Typos.find(options)
-    |> print_typo_candidates()
-  end
-
-  defp print_typo_candidates(possible_typos) do
-    Enum.each(possible_typos, fn {word, {compared_word, score, list_of_occurrences}} ->
-      IO.puts("-> \"#{word}\" looks like \"#{compared_word}\" (#{score})")
-
-      Enum.each(list_of_occurrences, fn {file, lines} ->
-        """
-          -> #{file}
-            -> Lines: #{Enum.join(lines, ", ")}
-        """
-        |> IO.puts()
-      end)
-    end)
-
-    :ok
+    |> Output.print_candidates()
   end
 
   @doc """

--- a/lib/typo_killer/candidate.ex
+++ b/lib/typo_killer/candidate.ex
@@ -1,0 +1,12 @@
+defmodule TypoKiller.Candidate do
+  @moduledoc """
+  """
+  defstruct [:word, :similar_word, :score, :occurrences]
+
+  @type t :: %__MODULE__{
+          word: String.t(),
+          similar_word: String.t(),
+          score: number,
+          occurrences: [{String.t(), [non_neg_integer]}]
+        }
+end

--- a/lib/typo_killer/output.ex
+++ b/lib/typo_killer/output.ex
@@ -1,0 +1,51 @@
+defmodule TypoKiller.Output do
+  @moduledoc """
+  Functions to pretty print results
+  """
+
+  alias TypoKiller.Candidate
+
+  @doc """
+  Pretty print a list of candidates
+  """
+  @spec print_candidates([Candidate.t()]) :: :ok
+  def print_candidates(candidates) do
+    Enum.each(candidates, fn candidate ->
+      """
+      ┌ #{candidate.word}
+      ├──┬─ Similar to: #{candidate.similar_word}
+      │  └─ Score: #{candidate.score}
+      │
+      """
+      |> IO.write()
+
+      print(candidate.occurrences, &print_middle/1, &print_last/1)
+    end)
+  end
+
+  defp print_middle({file, lines}) do
+    """
+    ├──┬─ File: #{file}
+    │  └─ Lines: #{Enum.join(lines, ", ")}
+    │
+    """
+    |> IO.write()
+  end
+
+  defp print_last({file, lines}) do
+    """
+    └──┬─ File: #{file}
+       └─ Lines: #{Enum.join(lines, ", ")}
+    """
+    |> IO.puts()
+  end
+
+  defp print([last], _middle_fn, last_fn) do
+    last_fn.(last)
+  end
+
+  defp print([element | remaining], middle_fn, last_fn) do
+    middle_fn.(element)
+    print(remaining, middle_fn, last_fn)
+  end
+end

--- a/lib/typo_killer/words.ex
+++ b/lib/typo_killer/words.ex
@@ -9,6 +9,8 @@ defmodule TypoKiller.Words do
 
   @ignored_words_mapset MapSet.new(@ignored_words_list)
 
+  alias TypoKiller.Candidate
+
   @doc """
   Parses a list of files to extract words and their occurrences (file and line)
   """
@@ -23,7 +25,7 @@ defmodule TypoKiller.Words do
     |> Flow.map(&parse_file/1)
     |> Enum.to_list()
     |> Enum.reduce({MapSet.new(), %{}}, &merge_file_list_results/2)
-    |> build_dict()
+    |> build_result()
   end
 
   defp parse_file(file) do
@@ -78,9 +80,17 @@ defmodule TypoKiller.Words do
     end)
   end
 
-  defp build_dict({words, word_map}) do
+  defp build_result({words, word_map}) do
     dictionary = MapSet.union(words, @ignored_words_mapset)
 
-    {words, dictionary, word_map}
+    candidates =
+      Enum.map(words, fn word ->
+        %Candidate{
+          word: word,
+          occurrences: Map.get(word_map, word)
+        }
+      end)
+
+    {candidates, dictionary}
   end
 end


### PR DESCRIPTION
Instead of relying only on tuples, now we'll have an actual struct
to hold the data across the pipeline.

**Bonus:** new pretty output built with ascii chars :D

```
┌ extracts
├─┬─ Similar to: extract
│ └─ Score: 0.9583333333333334
└─┐
  └─┬─ File: ./lib/typo_killer/words.ex
    └─ Lines: 3

┌ occurrences
├─┬─ Similar to: occurrence
│ └─ Score: 0.9696969696969697
└─┐
  ├─┬─ File: ./lib/typo_killer/candidate.ex
  │ └─ Lines: 10, 4
  │
  ├─┬─ File: ./lib/typo_killer/words.ex
  │ └─ Lines: 90, 54, 53, 52, 15
  │
  └─┬─ File: ./lib/typo_killer/output.ex
    └─ Lines: 22

┌ commits
├─┬─ Similar to: commit
│ └─ Score: 0.9523809523809524
└─┐
  └─┬─ File: ./lib/typo_killer.ex
    └─ Lines: 9
```